### PR TITLE
ci(pre-commit): update pre-commit-hooks-ros

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,10 +34,13 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.4.0
+    rev: v0.6.0
     hooks:
+      - id: prettier-xacro
+      - id: prettier-launch-xml
       - id: prettier-package-xml
       - id: sort-package-xml
+      - id: ros-include-guard
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.8.0.3


### PR DESCRIPTION
See https://github.com/tier4/pre-commit-hooks-ros/pull/50 and https://github.com/tier4/pre-commit-hooks-ros/releases/tag/v0.6.0.

Related: https://github.com/autowarefoundation/autoware/pull/143