### PR TITLE
fix: add missing imu corrector param

### DIFF
--- a/individual_params/config/default/sample_sensor_kit/imu_corrector.param.yaml
+++ b/individual_params/config/default/sample_sensor_kit/imu_corrector.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    angular_velocity_offset_x: 0.0    # [rad/s]
+    angular_velocity_offset_y: 0.0    # [rad/s]
+    angular_velocity_offset_z: 0.0    # [rad/s]
+    angular_velocity_stddev_xx: 0.03  # [rad/s]
+    angular_velocity_stddev_yy: 0.03  # [rad/s]
+    angular_velocity_stddev_zz: 0.03  # [rad/s]


### PR DESCRIPTION
## Description

fix the following error
```
[WARNING] [launch_ros.actions.node]: Parameter file path is not a file: /home/daisuke/workspace/autoware/install/individual_params/share/individual_params/config/default/sample_sensor_kit/imu_corrector.param.yaml
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
