### PR TITLE
chore: adjust left & right lidar positions for awsim_labs/lexus

### DIFF
--- a/individual_params/config/default/awsim_labs_sensor_kit/sensor_kit_calibration.yaml
+++ b/individual_params/config/default/awsim_labs_sensor_kit/sensor_kit_calibration.yaml
@@ -1,0 +1,92 @@
+sensor_kit_base_link:
+  camera0/camera_link:
+    x: 0.10731
+    y: 0.56343
+    z: -0.27697
+    roll: -0.025
+    pitch: 0.315
+    yaw: 1.035
+  camera1/camera_link:
+    x: -0.10731
+    y: -0.56343
+    z: -0.27697
+    roll: -0.025
+    pitch: 0.32
+    yaw: -2.12
+  camera2/camera_link:
+    x: 0.10731
+    y: -0.56343
+    z: -0.27697
+    roll: -0.00
+    pitch: 0.335
+    yaw: -1.04
+  camera3/camera_link:
+    x: -0.10731
+    y: 0.56343
+    z: -0.27697
+    roll: 0.0
+    pitch: 0.325
+    yaw: 2.0943951
+  camera4/camera_link:
+    x: 0.07356
+    y: 0.0
+    z: -0.0525
+    roll: 0.0
+    pitch: -0.03
+    yaw: -0.005
+  camera5/camera_link:
+    x: -0.07356
+    y: 0.0
+    z: -0.0525
+    roll: 0.0
+    pitch: -0.01
+    yaw: 3.125
+  traffic_light_right_camera/camera_link:
+    x: 0.05
+    y: -0.0175
+    z: -0.1
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0
+  traffic_light_left_camera/camera_link:
+    x: 0.05
+    y: 0.0175
+    z: -0.1
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0
+  velodyne_top_base_link:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    roll: 0.0
+    pitch: 0.0
+    yaw: 1.575
+  velodyne_left_base_link:
+    x: 0.0
+    y: 0.59
+    z: -0.30555
+    roll: -0.02
+    pitch: 0.71
+    yaw: 1.575
+  velodyne_right_base_link:
+    x: 0.0
+    y: -0.59
+    z: -0.30555
+    roll: -0.01
+    pitch: 0.71
+    yaw: -1.580
+  gnss_link:
+    x: -0.1
+    y: 0.0
+    z: -0.2
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0
+  tamagawa/imu_link:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    roll: 3.14159265359
+    pitch: 0.0
+    yaw: 3.14159265359

--- a/individual_params/config/default/awsim_labs_sensor_kit/sensors_calibration.yaml
+++ b/individual_params/config/default/awsim_labs_sensor_kit/sensors_calibration.yaml
@@ -1,0 +1,15 @@
+base_link:
+  sensor_kit_base_link:
+    x: 0.9
+    y: 0.0
+    z: 2.0
+    roll: -0.001
+    pitch: 0.015
+    yaw: -0.0364
+  velodyne_rear_base_link:
+    x: -0.358
+    y: 0.0
+    z: 1.631
+    roll: -0.02
+    pitch: 0.7281317
+    yaw: 3.141592

--- a/individual_params/config/default/awsim_sensor_kit/sensor_kit_calibration.yaml
+++ b/individual_params/config/default/awsim_sensor_kit/sensor_kit_calibration.yaml
@@ -64,14 +64,14 @@ sensor_kit_base_link:
     yaw: 1.575
   velodyne_left_base_link:
     x: 0.0
-    y: 0.59
+    y: 0.56362
     z: -0.30555
     roll: -0.02
     pitch: 0.71
     yaw: 1.575
   velodyne_right_base_link:
     x: 0.0
-    y: -0.59
+    y: -0.56362
     z: -0.30555
     roll: -0.01
     pitch: 0.71

--- a/individual_params/config/default/awsim_sensor_kit/sensor_kit_calibration.yaml
+++ b/individual_params/config/default/awsim_sensor_kit/sensor_kit_calibration.yaml
@@ -64,14 +64,14 @@ sensor_kit_base_link:
     yaw: 1.575
   velodyne_left_base_link:
     x: 0.0
-    y: 0.56362
+    y: 0.59
     z: -0.30555
     roll: -0.02
     pitch: 0.71
     yaw: 1.575
   velodyne_right_base_link:
     x: 0.0
-    y: -0.56362
+    y: -0.59
     z: -0.30555
     roll: -0.01
     pitch: 0.71


### PR DESCRIPTION
## Description

This PR changes left and right lidar positions slightly for AWSIM Lexus sensor config.

Reason behind this change: 
- https://github.com/autowarefoundation/AWSIM/issues/51

Related PR on AWSIM Labs:
- https://github.com/autowarefoundation/AWSIM/pull/54

Part of:
- https://github.com/autowarefoundation/autoware/issues/4659

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
