### PR TITLE
fix: awsim_labs velodyne_top_base_link yaw value

### DIFF
--- a/individual_params/config/default/awsim_labs_sensor_kit/sensor_kit_calibration.yaml
+++ b/individual_params/config/default/awsim_labs_sensor_kit/sensor_kit_calibration.yaml
@@ -61,7 +61,7 @@ sensor_kit_base_link:
     z: 0.0
     roll: 0.0
     pitch: 0.0
-    yaw: 1.575
+    yaw: 0.0
   velodyne_left_base_link:
     x: 0.0
     y: 0.59


### PR DESCRIPTION
## Description

Fix AWSIM Labs sensor kit, "velodyne_top_base_link" yaw value.

Reason for this change:

When we are importing vehicle sensor config  that generated from the Autoware to the Unity with our [Dynamic Sensor Placement tool](https://autowarefoundation.github.io/AWSIM-Labs/main/Components/Vehicle/DynamicSensorPlacement/) the vehicle localizes with a 90 degree error. 
To prevent this, I've changed **velodyne_top_base_link** yaw value to **"0"**. Since it shouldn't have a rotation difference from the "sensor_kit_base_link"
## Related Links
- https://github.com/autowarefoundation/AWSIM-Labs/issues/79
- https://github.com/autowarefoundation/AWSIM-Labs/pull/81

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
